### PR TITLE
Fix #3: OpenCV library. project.properties will not be updated anymore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ Thumbs.db
 .Spotlight-V100
 .Trashes
 ehthumbs.db
+
+# Every developer will have OpenCV sdk installed in their own path
+project.properties
+

--- a/AndroidOpenCVDemo/project.properties
+++ b/AndroidOpenCVDemo/project.properties
@@ -12,3 +12,4 @@
 
 # Project target.
 target=android-21
+android.library.reference.1=../../OpenCV-2.4.10-android-sdk/sdk/java


### PR DESCRIPTION
By default sdk will be located outside git clone, just one level up. Please, change it accord with your own setup.

To avoid changes of project.properties because different paths between developers, that file will not be updated anymore.
